### PR TITLE
fix: Register aliases after default command registration phase

### DIFF
--- a/src/main/java/me/flashyreese/mods/commandaliases/command/loader/CommandAliasesLoader.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/loader/CommandAliasesLoader.java
@@ -47,7 +47,8 @@ public class CommandAliasesLoader {
     }
 
     public void registerCommandAliases() {
-        // Any time commands get registered in the future, re-register CommandAliases nodes.
+        // CommandAliases must perform registration after all other mods, so that mod-added commands can be referenced
+        // in Aliases. We add our own phase that must execute after the default phase to achieve this.
         CommandRegistrationCallback.EVENT.addPhaseOrdering(Event.DEFAULT_PHASE, ALIASES_REGISTRATION_PHASE_ID);
         CommandRegistrationCallback.EVENT.register(
             ALIASES_REGISTRATION_PHASE_ID,

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/loader/CommandAliasesLoader.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/loader/CommandAliasesLoader.java
@@ -1,9 +1,7 @@
 package me.flashyreese.mods.commandaliases.command.loader;
 
-import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.flashyreese.mods.commandaliases.CommandAliasesMod;
-import me.flashyreese.mods.commandaliases.command.CommandManagerExtended;
 import me.flashyreese.mods.commandaliases.command.Scheduler;
 import me.flashyreese.mods.commandaliases.config.CommandAliasesConfig;
 import me.flashyreese.mods.commandaliases.storage.database.leveldb.LevelDBImpl;
@@ -13,12 +11,12 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallba
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.WorldSavePath;
 
 import java.lang.reflect.Field;
@@ -32,9 +30,9 @@ import java.lang.reflect.Field;
  */
 public class CommandAliasesLoader {
 
+    private static final Identifier ALIASES_REGISTRATION_PHASE_ID = Identifier.of("commandaliases", "register_aliases_phase");
     private final AbstractCommandAliasesProvider<ServerCommandSource> serverCommandAliasesProvider;
     private final AbstractCommandAliasesProvider<FabricClientCommandSource> clientCommandAliasesProvider;
-    private boolean isServerStarted = false;
 
     public CommandAliasesLoader() {
         Field literalCommandNodeLiteralField = null;
@@ -49,31 +47,17 @@ public class CommandAliasesLoader {
     }
 
     public void registerCommandAliases() {
-
-        CommandRegistrationCallback handleRegister = (dispatcher, registryAccess, environment) -> {
-            this.serverCommandAliasesProvider.registerCommandAliasesCommands(dispatcher, registryAccess);
-            this.serverCommandAliasesProvider.loadCommandAliases();
-            this.serverCommandAliasesProvider.registerCommands(dispatcher, registryAccess);
-        };
-
         // Any time commands get registered in the future, re-register CommandAliases nodes.
+        CommandRegistrationCallback.EVENT.addPhaseOrdering(Event.DEFAULT_PHASE, ALIASES_REGISTRATION_PHASE_ID);
         CommandRegistrationCallback.EVENT.register(
+            ALIASES_REGISTRATION_PHASE_ID,
             (dispatcher, registryAccess, environment) -> {
-                // On server startup, registration will be handled in the `SERVER_STARTED` callback, so that it always
-                // occurs after all other mods have registered their commands.
-                if (isServerStarted) {
-                    handleRegister.register(dispatcher, registryAccess, environment);
-                }
+                this.serverCommandAliasesProvider.registerCommandAliasesCommands(dispatcher, registryAccess);
+                this.serverCommandAliasesProvider.loadCommandAliases();
+                this.serverCommandAliasesProvider.registerCommands(dispatcher, registryAccess);
             });
 
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
-            // CommandRegistrationCallback.EVENT won't work here because it gets called before the server even starts.
-            CommandDispatcher<ServerCommandSource> dispatcher = server.getCommandManager().getDispatcher();
-            CommandRegistryAccess registryAccess = ((CommandManagerExtended) server.getCommandManager()).getCommandRegistryAccess();
-            CommandManager.RegistrationEnvironment environment = ((CommandManagerExtended) server.getCommandManager()).getEnvironment();
-            // Immediately register on server start, (after all other mods have registered their commands)
-            handleRegister.register(dispatcher, registryAccess, environment);
-
             if (this.serverCommandAliasesProvider.getDatabase() == null) {
                 if (CommandAliasesMod.options().databaseSettings.databaseMode == CommandAliasesConfig.DatabaseMode.LEVELDB) {
                     this.serverCommandAliasesProvider.setDatabase(new LevelDBImpl(server.getSavePath(WorldSavePath.ROOT).resolve("commandaliases").toString()));
@@ -88,12 +72,8 @@ public class CommandAliasesLoader {
             if (this.serverCommandAliasesProvider.getScheduler() == null) {
                 this.serverCommandAliasesProvider.setScheduler(new Scheduler());
             }
-
-            isServerStarted = true;
         });
         ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
-            isServerStarted = false;
-
             if (this.serverCommandAliasesProvider.getDatabase() != null) {
                 this.serverCommandAliasesProvider.getDatabase().close();
                 this.serverCommandAliasesProvider.setDatabase(null);


### PR DESCRIPTION
Immediately register on server start. Re-register on CommandRegistrationCallback.EVENT

Resolves #34 

---

Not sure I'm a fan of this approach. Having to keep track of `isServerStarted` state is annoying, but I don't think I have a cleaner approach atm.

---

I've not tested this yet, because the current state of the `1.19.x/dev` branch seems to just never register commands for me. Looking into that locally...
