### PR TITLE
Minecraft Version - Update to 26.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-	id 'fabric-loom' version '1.11-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version '1.16-SNAPSHOT'
 	id 'maven-publish'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 
@@ -37,17 +37,16 @@ repositories {
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// Permissions API
-	include(modImplementation("me.lucko:fabric-permissions-api:0.5.0"))
+	include(implementation("me.lucko:fabric-permissions-api:0.7.0"))
 
 	// Placeholders API
-	modImplementation include("eu.pb4:placeholder-api:2.8.0+1.21.9")
+	implementation include("eu.pb4:placeholder-api:3.0.0+26.1")
 
 	// LevelDB
 	include(implementation("org.iq80.leveldb:leveldb:0.12"))
@@ -70,11 +69,6 @@ dependencies {
 
 	// Math Evaluator
 	include(implementation("com.fathzer:javaluator:3.0.6"))
-
-	//modRuntimeOnly "maven.modrinth:lazydfu:0.1.3"
-	//modRuntimeOnly "maven.modrinth:sodium:mc1.19-0.4.2"
-	//modRuntimeOnly "maven.modrinth:lithium:mc1.19-0.8.0"
-	//modRuntimeOnly "maven.modrinth:phosphor:mc1.19.x-0.8.1"
 }
 
 processResources {
@@ -86,8 +80,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,18 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
+org.gradle.parallel=true
+org.gradle.configuration-cache=false
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
-    minecraft_version=1.21.9
-    yarn_mappings=1.21.9+build.1
-	loader_version=0.17.2
+	# check these on https://fabricmc.net/develop
+    minecraft_version=26.1.2
+	loader_version=0.19.2
 
 # Mod Properties
-	mod_version = 1.0.3
+	mod_version = 1.0.4
 	maven_group = me.flashyreese.mods
 	archives_base_name = commandaliases
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.134.0+1.21.9
+	fabric_version=0.146.0+26.1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/CommandManagerExtended.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/CommandManagerExtended.java
@@ -1,7 +1,7 @@
 package me.flashyreese.mods.commandaliases.command;
 
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.server.command.CommandManager;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.Commands;
 
 /**
  * Accessor for CommandManager
@@ -11,7 +11,7 @@ import net.minecraft.server.command.CommandManager;
  * @since 0.7.0
  */
 public interface CommandManagerExtended {
-    CommandManager.RegistrationEnvironment getEnvironment();
+    Commands.CommandSelection getEnvironment();
 
-    CommandRegistryAccess getCommandRegistryAccess();
+    CommandBuildContext getCommandRegistryAccess();
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/Permissions.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/Permissions.java
@@ -1,7 +1,7 @@
 package me.flashyreese.mods.commandaliases.command;
 
 import net.fabricmc.fabric.api.util.TriState;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.SharedSuggestionProvider;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -18,7 +18,7 @@ public class Permissions {
      * @param defaultValue the default value to use if nothing has been set
      * @return a predicate that will perform the permission check
      */
-    public static <S extends CommandSource> @NotNull Predicate<S> require(@NotNull String permission, boolean defaultValue) {
+    public static <S extends SharedSuggestionProvider> @NotNull Predicate<S> require(@NotNull String permission, boolean defaultValue) {
         Objects.requireNonNull(permission, "permission");
         return player -> check(player, permission, defaultValue);
     }
@@ -32,7 +32,7 @@ public class Permissions {
      * @param defaultRequiredLevel the required permission level to check for as a fallback
      * @return a predicate that will perform the permission check
      */
-    public static <S extends CommandSource> @NotNull Predicate<S> require(@NotNull String permission, int defaultRequiredLevel) {
+    public static <S extends SharedSuggestionProvider> @NotNull Predicate<S> require(@NotNull String permission, int defaultRequiredLevel) {
         Objects.requireNonNull(permission, "permission");
         return player -> check(player, permission, defaultRequiredLevel);
     }
@@ -44,7 +44,7 @@ public class Permissions {
      * @param permission the permission to check
      * @return a predicate that will perform the permission check
      */
-    public static <S extends CommandSource> @NotNull Predicate<S> require(@NotNull String permission) {
+    public static <S extends SharedSuggestionProvider> @NotNull Predicate<S> require(@NotNull String permission) {
         Objects.requireNonNull(permission, "permission");
         return player -> check(player, permission);
     }

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/builder/CommandBuilderDelegate.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/builder/CommandBuilderDelegate.java
@@ -4,7 +4,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.SharedSuggestionProvider;
 
 /**
  * Represents a command builder
@@ -13,7 +13,7 @@ import net.minecraft.command.CommandSource;
  * @version 0.5.0
  * @since 0.5.0
  */
-public interface CommandBuilderDelegate<S extends CommandSource> {
+public interface CommandBuilderDelegate<S extends SharedSuggestionProvider> {
     LiteralArgumentBuilder<S> buildCommand(CommandDispatcher<S> dispatcher);
 
     default LiteralArgumentBuilder<S> literal(String literal) {

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/builder/custom/AbstractCustomCommandBuilder.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/builder/custom/AbstractCustomCommandBuilder.java
@@ -24,8 +24,8 @@ import me.flashyreese.mods.commandaliases.command.impl.ArgumentTypeMapper;
 import me.flashyreese.mods.commandaliases.command.impl.FunctionProcessor;
 import me.flashyreese.mods.commandaliases.command.impl.InputMapper;
 import me.flashyreese.mods.commandaliases.command.loader.AbstractCommandAliasesProvider;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.SharedSuggestionProvider;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @version 1.0.0
  * @since 0.4.0
  */
-public abstract class AbstractCustomCommandBuilder<S extends CommandSource> implements CommandBuilderDelegate<S> {
+public abstract class AbstractCustomCommandBuilder<S extends SharedSuggestionProvider> implements CommandBuilderDelegate<S> {
 
     protected final String filePath;
     protected final CustomCommand commandAliasParent;
@@ -54,7 +54,7 @@ public abstract class AbstractCustomCommandBuilder<S extends CommandSource> impl
 
     protected final AbstractCommandAliasesProvider<S> abstractCommandAliasesProvider;
 
-    public AbstractCustomCommandBuilder(String filePath, CustomCommand commandAliasParent, AbstractCommandAliasesProvider<S> abstractCommandAliasesProvider, CommandRegistryAccess registryAccess, CommandType commandType) {
+    public AbstractCustomCommandBuilder(String filePath, CustomCommand commandAliasParent, AbstractCommandAliasesProvider<S> abstractCommandAliasesProvider, CommandBuildContext registryAccess, CommandType commandType) {
         this.filePath = filePath;
         this.argumentTypeMapper = new ArgumentTypeMapper(registryAccess);
         this.commandAliasParent = commandAliasParent;
@@ -243,7 +243,7 @@ public abstract class AbstractCustomCommandBuilder<S extends CommandSource> impl
                             \tProcessing time: {}ms
                             \t======================================================""", formattedSuggestion, (end - start) / 1000000.0);
                 }
-                return CommandSource.suggestMatching(suggestions.stream().map(StringArgumentType::escapeIfRequired), builder);
+                return SharedSuggestionProvider.suggest(suggestions.stream().map(StringArgumentType::escapeIfRequired), builder);
             };
         } else {
             SUGGESTION_PROVIDER = (context, builder) -> {
@@ -264,7 +264,7 @@ public abstract class AbstractCustomCommandBuilder<S extends CommandSource> impl
                             \t"Processing time: {}ms
                             \t======================================================""", formattedSuggestion, (end - start) / 1000000.0);
                 }
-                return CommandSource.suggestMatching(suggestions.stream().map(StringArgumentType::escapeIfRequired), builder);
+                return SharedSuggestionProvider.suggest(suggestions.stream().map(StringArgumentType::escapeIfRequired), builder);
             };
         }
 

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/builder/custom/ClientCustomCommandBuilder.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/builder/custom/ClientCustomCommandBuilder.java
@@ -9,8 +9,8 @@ import me.flashyreese.mods.commandaliases.command.builder.custom.format.CustomCo
 import me.flashyreese.mods.commandaliases.command.builder.custom.format.CustomCommandAction;
 import me.flashyreese.mods.commandaliases.command.loader.AbstractCommandAliasesProvider;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.text.Text;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.network.chat.Component;
 
 /**
  * Represents the Client Custom Command Builder
@@ -22,7 +22,7 @@ import net.minecraft.text.Text;
  * @since 0.5.0
  */
 public class ClientCustomCommandBuilder extends AbstractCustomCommandBuilder<FabricClientCommandSource> {
-    public ClientCustomCommandBuilder(String filePath, CustomCommand commandAliasParent, AbstractCommandAliasesProvider<FabricClientCommandSource> abstractCommandAliasesProvider, CommandRegistryAccess registryAccess) {
+    public ClientCustomCommandBuilder(String filePath, CustomCommand commandAliasParent, AbstractCommandAliasesProvider<FabricClientCommandSource> abstractCommandAliasesProvider, CommandBuildContext registryAccess) {
         super(filePath, commandAliasParent, abstractCommandAliasesProvider, registryAccess, CommandType.CLIENT);
     }
 
@@ -32,7 +32,7 @@ public class ClientCustomCommandBuilder extends AbstractCustomCommandBuilder<Fab
         if (action.getCommandType() == CommandType.CLIENT) {
             state = dispatcher.execute(actionCommand, context.getSource());
         } else if (action.getCommandType() == CommandType.SERVER) {
-            context.getSource().getPlayer().networkHandler.sendChatCommand(actionCommand); // Todo: Dangerous might cause abuse by spammers
+            context.getSource().getPlayer().connection.sendCommand(actionCommand); // Todo: Dangerous might cause abuse by spammers
             state = Command.SINGLE_SUCCESS;
         }
         return state;
@@ -40,6 +40,6 @@ public class ClientCustomCommandBuilder extends AbstractCustomCommandBuilder<Fab
 
     @Override
     protected void sendFeedback(CommandContext<FabricClientCommandSource> context, String message) {
-        context.getSource().sendFeedback(Text.literal(message));
+        context.getSource().sendFeedback(Component.literal(message));
     }
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/builder/custom/ServerCustomCommandBuilder.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/builder/custom/ServerCustomCommandBuilder.java
@@ -3,16 +3,16 @@ package me.flashyreese.mods.commandaliases.command.builder.custom;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import eu.pb4.placeholders.api.PlaceholderContext;
 import eu.pb4.placeholders.api.Placeholders;
+import eu.pb4.placeholders.api.ServerPlaceholderContext;
 import me.flashyreese.mods.commandaliases.CommandAliasesMod;
 import me.flashyreese.mods.commandaliases.command.CommandType;
 import me.flashyreese.mods.commandaliases.command.builder.custom.format.CustomCommand;
 import me.flashyreese.mods.commandaliases.command.builder.custom.format.CustomCommandAction;
 import me.flashyreese.mods.commandaliases.command.loader.AbstractCommandAliasesProvider;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.text.Text;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
 
 import java.util.List;
 
@@ -25,34 +25,34 @@ import java.util.List;
  * @version 1.0.0
  * @since 0.5.0
  */
-public class ServerCustomCommandBuilder extends AbstractCustomCommandBuilder<ServerCommandSource> {
-    public ServerCustomCommandBuilder(String filePath, CustomCommand commandAliasParent, AbstractCommandAliasesProvider<ServerCommandSource> abstractCommandAliasesProvider, CommandRegistryAccess registryAccess) {
+public class ServerCustomCommandBuilder extends AbstractCustomCommandBuilder<CommandSourceStack> {
+    public ServerCustomCommandBuilder(String filePath, CustomCommand commandAliasParent, AbstractCommandAliasesProvider<CommandSourceStack> abstractCommandAliasesProvider, CommandBuildContext registryAccess) {
         super(filePath, commandAliasParent, abstractCommandAliasesProvider, registryAccess, CommandType.SERVER);
     }
 
     @Override
-    protected String formatString(CommandContext<ServerCommandSource> context, List<String> currentInputList, String string) {
+    protected String formatString(CommandContext<CommandSourceStack> context, List<String> currentInputList, String string) {
         string = super.formatString(context, currentInputList, string);
 
         // Placeholder API processor
-        string = Placeholders.parseText(Text.literal(string), PlaceholderContext.of(context.getSource())).getString();
+        string = Placeholders.SERVER_PLACEHOLDER_PARSER.parseComponent(string, ServerPlaceholderContext.of(context.getSource()).asParserContext()).getString();
 
         return string;
     }
 
     @Override
-    protected int dispatcherExecute(CustomCommandAction action, CommandDispatcher<ServerCommandSource> dispatcher, CommandContext<ServerCommandSource> context, String actionCommand) throws CommandSyntaxException {
+    protected int dispatcherExecute(CustomCommandAction action, CommandDispatcher<CommandSourceStack> dispatcher, CommandContext<CommandSourceStack> context, String actionCommand) throws CommandSyntaxException {
         int state = 0;
         if (action.getCommandType() == CommandType.CLIENT) {
             state = dispatcher.execute(actionCommand, context.getSource());
         } else if (action.getCommandType() == CommandType.SERVER) {
-            state = dispatcher.execute(actionCommand, context.getSource().getServer().getCommandSource());
+            state = dispatcher.execute(actionCommand, context.getSource().getServer().createCommandSourceStack());
         }
         return state;
     }
 
     @Override
-    protected void sendFeedback(CommandContext<ServerCommandSource> context, String message) {
-        context.getSource().sendFeedback(() -> Text.literal(message), CommandAliasesMod.options().debugSettings.broadcastToOps);
+    protected void sendFeedback(CommandContext<CommandSourceStack> context, String message) {
+        context.getSource().sendSuccess(() -> Component.literal(message), CommandAliasesMod.options().debugSettings.broadcastToOps);
     }
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/builder/reassign/ReassignCommandBuilder.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/builder/reassign/ReassignCommandBuilder.java
@@ -7,7 +7,7 @@ import me.flashyreese.mods.commandaliases.CommandAliasesMod;
 import me.flashyreese.mods.commandaliases.command.CommandType;
 import me.flashyreese.mods.commandaliases.command.builder.CommandBuilderDelegate;
 import me.flashyreese.mods.commandaliases.command.builder.reassign.format.ReassignCommand;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.SharedSuggestionProvider;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.Map;
  * @version 1.0.0
  * @since 0.3.0
  */
-public class ReassignCommandBuilder<S extends CommandSource> implements CommandBuilderDelegate<S> {
+public class ReassignCommandBuilder<S extends SharedSuggestionProvider> implements CommandBuilderDelegate<S> {
     protected final String filePath;
     protected final ReassignCommand command;
     protected final Map<String, String> reassignCommandMap;

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/builder/redirect/CommandRedirectBuilder.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/builder/redirect/CommandRedirectBuilder.java
@@ -9,7 +9,7 @@ import me.flashyreese.mods.commandaliases.command.CommandMode;
 import me.flashyreese.mods.commandaliases.command.CommandType;
 import me.flashyreese.mods.commandaliases.command.builder.CommandBuilderDelegate;
 import me.flashyreese.mods.commandaliases.command.builder.redirect.format.RedirectCommand;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.SharedSuggestionProvider;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @version 0.5.0
  * @since 0.3.0
  */
-public class CommandRedirectBuilder<S extends CommandSource> implements CommandBuilderDelegate<S> {
+public class CommandRedirectBuilder<S extends SharedSuggestionProvider> implements CommandBuilderDelegate<S> {
     private final String filePath;
     private final RedirectCommand command;
     private final CommandType commandType;

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/impl/ArgumentTypeMapper.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/impl/ArgumentTypeMapper.java
@@ -5,9 +5,15 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.context.ParsedArgument;
 import com.mojang.brigadier.context.StringRange;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.command.argument.*;
-import net.minecraft.registry.RegistryKeys;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.arguments.*;
+import net.minecraft.commands.arguments.blocks.BlockPredicateArgument;
+import net.minecraft.commands.arguments.blocks.BlockStateArgument;
+import net.minecraft.commands.arguments.coordinates.*;
+import net.minecraft.commands.arguments.item.FunctionArgument;
+import net.minecraft.commands.arguments.item.ItemArgument;
+import net.minecraft.commands.arguments.item.ItemPredicateArgument;
+import net.minecraft.core.registries.Registries;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -28,7 +34,7 @@ public class ArgumentTypeMapper { // Todo: Singleton instance - Map registry via
 
     private Field commandContextArgumentsField = null;
 
-    public ArgumentTypeMapper(CommandRegistryAccess registryAccess) {
+    public ArgumentTypeMapper(CommandBuildContext registryAccess) {
         this.registerArgumentTypes(registryAccess);
         try {
             this.commandContextArgumentsField = CommandContext.class.getDeclaredField("arguments");
@@ -38,74 +44,74 @@ public class ArgumentTypeMapper { // Todo: Singleton instance - Map registry via
         }
     }
 
-    private void registerArgumentTypes(CommandRegistryAccess registryAccess) {
+    private void registerArgumentTypes(CommandBuildContext registryAccess) {
         this.argumentMap.put("minecraft:word", StringArgumentType.word());
         this.argumentMap.put("minecraft:string", StringArgumentType.string());
         this.argumentMap.put("minecraft:greedy_string", StringArgumentType.greedyString());
 
-        this.argumentMap.put("minecraft:entity", EntityArgumentType.entity());
-        this.argumentMap.put("minecraft:entities", EntityArgumentType.entities());
-        this.argumentMap.put("minecraft:player", EntityArgumentType.player());
-        this.argumentMap.put("minecraft:players", EntityArgumentType.players());
+        this.argumentMap.put("minecraft:entity", EntityArgument.entity());
+        this.argumentMap.put("minecraft:entities", EntityArgument.entities());
+        this.argumentMap.put("minecraft:player", EntityArgument.player());
+        this.argumentMap.put("minecraft:players", EntityArgument.players());
 
-        this.argumentMap.put("minecraft:score_holder", ScoreHolderArgumentType.scoreHolder());
-        this.argumentMap.put("minecraft:score_holders", ScoreHolderArgumentType.scoreHolders());
+        this.argumentMap.put("minecraft:score_holder", ScoreHolderArgument.scoreHolder());
+        this.argumentMap.put("minecraft:score_holders", ScoreHolderArgument.scoreHolders());
 
-        this.argumentMap.put("minecraft:game_profile", GameProfileArgumentType.gameProfile());
-        this.argumentMap.put("minecraft:block_pos", BlockPosArgumentType.blockPos()); // fixme: Relative pos - we should parse this them convert to string, should we fix this? or should we not? because pain
-        this.argumentMap.put("minecraft:column_pos", ColumnPosArgumentType.columnPos()); //
-        this.argumentMap.put("minecraft:vec3", Vec3ArgumentType.vec3()); //
-        this.argumentMap.put("minecraft:vec2", Vec2ArgumentType.vec2()); //
-        this.argumentMap.put("minecraft:block_state", BlockStateArgumentType.blockState(registryAccess));
-        this.argumentMap.put("minecraft:block_predicate", BlockPredicateArgumentType.blockPredicate(registryAccess));
-        this.argumentMap.put("minecraft:item_stack", ItemStackArgumentType.itemStack(registryAccess));
-        this.argumentMap.put("minecraft:item_predicate", ItemPredicateArgumentType.itemPredicate(registryAccess));
-        this.argumentMap.put("minecraft:color", ColorArgumentType.color());
-        this.argumentMap.put("minecraft:component", TextArgumentType.text(registryAccess));
-        this.argumentMap.put("minecraft:message", MessageArgumentType.message());
-        this.argumentMap.put("minecraft:nbt_compound_tag", NbtCompoundArgumentType.nbtCompound());
-        this.argumentMap.put("minecraft:nbt_tag", NbtElementArgumentType.nbtElement());
-        this.argumentMap.put("minecraft:nbt_path", NbtPathArgumentType.nbtPath());
-        this.argumentMap.put("minecraft:objective", ScoreboardObjectiveArgumentType.scoreboardObjective());
-        this.argumentMap.put("minecraft:objective_criteria", ScoreboardCriterionArgumentType.scoreboardCriterion());
-        this.argumentMap.put("minecraft:operation", OperationArgumentType.operation());
-        this.argumentMap.put("minecraft:particle", ParticleEffectArgumentType.particleEffect(registryAccess));
-        this.argumentMap.put("minecraft:angle", AngleArgumentType.angle()); //
-        this.argumentMap.put("minecraft:rotation", RotationArgumentType.rotation()); //
-        this.argumentMap.put("minecraft:scoreboard_slot", ScoreboardSlotArgumentType.scoreboardSlot());
-        this.argumentMap.put("minecraft:swizzle", SwizzleArgumentType.swizzle());
-        this.argumentMap.put("minecraft:team", TeamArgumentType.team());
-        this.argumentMap.put("minecraft:item_slot", ItemSlotArgumentType.itemSlot());
-        this.argumentMap.put("minecraft:resource_location", IdentifierArgumentType.identifier());
-        this.argumentMap.put("minecraft:function", CommandFunctionArgumentType.commandFunction());
-        this.argumentMap.put("minecraft:entity_anchor", EntityAnchorArgumentType.entityAnchor());
-        this.argumentMap.put("minecraft:int_range", NumberRangeArgumentType.intRange()); // todo: range
-        this.argumentMap.put("minecraft:float_range", NumberRangeArgumentType.floatRange()); // todo :rage
-        this.argumentMap.put("minecraft:dimension", DimensionArgumentType.dimension());
-        this.argumentMap.put("minecraft:gamemode", GameModeArgumentType.gameMode());
-        this.argumentMap.put("minecraft:time", TimeArgumentType.time());
+        this.argumentMap.put("minecraft:game_profile", GameProfileArgument.gameProfile());
+        this.argumentMap.put("minecraft:block_pos", BlockPosArgument.blockPos());
+        this.argumentMap.put("minecraft:column_pos", ColumnPosArgument.columnPos());
+        this.argumentMap.put("minecraft:vec3", Vec3Argument.vec3());
+        this.argumentMap.put("minecraft:vec2", Vec2Argument.vec2());
+        this.argumentMap.put("minecraft:block_state", BlockStateArgument.block(registryAccess));
+        this.argumentMap.put("minecraft:block_predicate", BlockPredicateArgument.blockPredicate(registryAccess));
+        this.argumentMap.put("minecraft:item_stack", ItemArgument.item(registryAccess));
+        this.argumentMap.put("minecraft:item_predicate", ItemPredicateArgument.itemPredicate(registryAccess));
+        this.argumentMap.put("minecraft:color", ColorArgument.color());
+        this.argumentMap.put("minecraft:component", ComponentArgument.textComponent(registryAccess));
+        this.argumentMap.put("minecraft:message", MessageArgument.message());
+        this.argumentMap.put("minecraft:nbt_compound_tag", CompoundTagArgument.compoundTag());
+        this.argumentMap.put("minecraft:nbt_tag", NbtTagArgument.nbtTag());
+        this.argumentMap.put("minecraft:nbt_path", NbtPathArgument.nbtPath());
+        this.argumentMap.put("minecraft:objective", ObjectiveArgument.objective());
+        this.argumentMap.put("minecraft:objective_criteria", ObjectiveCriteriaArgument.criteria());
+        this.argumentMap.put("minecraft:operation", OperationArgument.operation());
+        this.argumentMap.put("minecraft:particle", ParticleArgument.particle(registryAccess));
+        this.argumentMap.put("minecraft:angle", AngleArgument.angle());
+        this.argumentMap.put("minecraft:rotation", RotationArgument.rotation());
+        this.argumentMap.put("minecraft:scoreboard_slot", ScoreboardSlotArgument.displaySlot());
+        this.argumentMap.put("minecraft:swizzle", SwizzleArgument.swizzle());
+        this.argumentMap.put("minecraft:team", TeamArgument.team());
+        this.argumentMap.put("minecraft:item_slot", SlotArgument.slot());
+        this.argumentMap.put("minecraft:resource_location", IdentifierArgument.id());
+        this.argumentMap.put("minecraft:function", FunctionArgument.functions());
+        this.argumentMap.put("minecraft:entity_anchor", EntityAnchorArgument.anchor());
+        this.argumentMap.put("minecraft:int_range", RangeArgument.intRange());
+        this.argumentMap.put("minecraft:float_range", RangeArgument.floatRange());
+        this.argumentMap.put("minecraft:dimension", DimensionArgument.dimension());
+        this.argumentMap.put("minecraft:gamemode", GameModeArgument.gameMode());
+        this.argumentMap.put("minecraft:time", TimeArgument.time());
 
         // Todo: Allow entire registry keys by creating registry map
-        this.argumentMap.put("minecraft:entry.attribute_key", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ATTRIBUTE));
-        this.argumentMap.put("minecraft:entry.status_effect_key", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.STATUS_EFFECT));
-        this.argumentMap.put("minecraft:entry.enchantment_type", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENCHANTMENT));
-        this.argumentMap.put("minecraft:entry.biome_key", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.BIOME));
-        this.argumentMap.put("minecraft:entry.entity_type_key", RegistryEntryReferenceArgumentType.registryEntry(registryAccess, RegistryKeys.ENTITY_TYPE));
+        this.argumentMap.put("minecraft:entry.attribute_key", ResourceArgument.resource(registryAccess, Registries.ATTRIBUTE));
+        this.argumentMap.put("minecraft:entry.status_effect_key", ResourceArgument.resource(registryAccess, Registries.MOB_EFFECT));
+        this.argumentMap.put("minecraft:entry.enchantment_type", ResourceArgument.resource(registryAccess, Registries.ENCHANTMENT));
+        this.argumentMap.put("minecraft:entry.biome_key", ResourceArgument.resource(registryAccess, Registries.BIOME));
+        this.argumentMap.put("minecraft:entry.entity_type_key", ResourceArgument.resource(registryAccess, Registries.ENTITY_TYPE));
 
-        this.argumentMap.put("minecraft:entry_predicate.biome_key", RegistryEntryPredicateArgumentType.registryEntryPredicate(registryAccess, RegistryKeys.BIOME));
-        this.argumentMap.put("minecraft:entry_predicate.poi_type_key", RegistryEntryPredicateArgumentType.registryEntryPredicate(registryAccess, RegistryKeys.POINT_OF_INTEREST_TYPE));
+        this.argumentMap.put("minecraft:entry_predicate.biome_key", ResourceOrTagArgument.resourceOrTag(registryAccess, Registries.BIOME));
+        this.argumentMap.put("minecraft:entry_predicate.poi_type_key", ResourceOrTagArgument.resourceOrTag(registryAccess, Registries.POINT_OF_INTEREST_TYPE));
 
-        this.argumentMap.put("minecraft:predicate.structure_key", RegistryPredicateArgumentType.registryPredicate(RegistryKeys.STRUCTURE));
+        this.argumentMap.put("minecraft:predicate.structure_key", ResourceOrTagKeyArgument.resourceOrTagKey(Registries.STRUCTURE));
 
-        this.argumentMap.put("minecraft:key.configured_feature_key", RegistryKeyArgumentType.registryKey(RegistryKeys.CONFIGURED_FEATURE));
-        this.argumentMap.put("minecraft:key.template_pool_key", RegistryKeyArgumentType.registryKey(RegistryKeys.TEMPLATE_POOL));
-        this.argumentMap.put("minecraft:key.structure_key", RegistryKeyArgumentType.registryKey(RegistryKeys.STRUCTURE));
+        this.argumentMap.put("minecraft:key.configured_feature_key", ResourceKeyArgument.key(Registries.CONFIGURED_FEATURE));
+        this.argumentMap.put("minecraft:key.template_pool_key", ResourceKeyArgument.key(Registries.TEMPLATE_POOL));
+        this.argumentMap.put("minecraft:key.structure_key", ResourceKeyArgument.key(Registries.STRUCTURE));
         // end
 
-        this.argumentMap.put("minecraft:template_mirror", BlockMirrorArgumentType.blockMirror());
-        this.argumentMap.put("minecraft:template_rotation", BlockRotationArgumentType.blockRotation());
+        this.argumentMap.put("minecraft:template_mirror", TemplateMirrorArgument.templateMirror());
+        this.argumentMap.put("minecraft:template_rotation", TemplateRotationArgument.templateRotation());
 
-        this.argumentMap.put("minecraft:uuid", UuidArgumentType.uuid());
+        this.argumentMap.put("minecraft:uuid", UuidArgument.uuid());
 
         this.argumentMap.put("brigadier:bool", BoolArgumentType.bool());
         this.argumentMap.put("brigadier:float", FloatArgumentType.floatArg());

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/impl/FunctionProcessor.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/impl/FunctionProcessor.java
@@ -4,10 +4,10 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import me.flashyreese.mods.commandaliases.CommandAliasesMod;
 import me.flashyreese.mods.commandaliases.command.loader.AbstractCommandAliasesProvider;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.minecraft.client.network.AbstractClientPlayerEntity;
-import net.minecraft.command.CommandSource;
-import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.server.level.ServerPlayer;
 
 import java.util.*;
 import java.util.function.BiFunction;
@@ -23,10 +23,10 @@ import java.util.regex.Pattern;
  * @version 0.8.0
  * @since 0.7.0
  */
-public class FunctionProcessor<S extends CommandSource> {
+public class FunctionProcessor<S extends SharedSuggestionProvider> {
     private final Pattern singleArgumentFunction = Pattern.compile("\\$(?<functionName>\\w+?)\\((?<arg>[+-]?(\\d+([.]\\d*)?|[.]\\d+)?|[\\w._]+?)\\)");
 
-    private final Map<String, BiFunction<CommandSource, String, String>> functionMap = new Object2ObjectOpenHashMap<>();
+    private final Map<String, BiFunction<SharedSuggestionProvider, String, String>> functionMap = new Object2ObjectOpenHashMap<>();
 
     private final AbstractCommandAliasesProvider<S> abstractCommandAliasesProvider;
 
@@ -37,10 +37,10 @@ public class FunctionProcessor<S extends CommandSource> {
 
     public void registerFunctions() {
         this.functionMap.put("executor_name", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                return serverCommandSource.getName();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                return serverCommandSource.getTextName();
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                return clientCommandSource.getPlayer().getNameForScoreboard();
+                return clientCommandSource.getPlayer().getScoreboardName();
             }
             return null;
         });
@@ -58,79 +58,79 @@ public class FunctionProcessor<S extends CommandSource> {
             return String.valueOf(new Random().nextInt());
         });
         this.functionMap.put("is_online", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                return String.valueOf(serverCommandSource.getWorld().getPlayers().stream().anyMatch(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)));
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                return String.valueOf(serverCommandSource.getLevel().players().stream().anyMatch(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)));
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                return String.valueOf(clientCommandSource.getWorld().getPlayers().stream().anyMatch(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)));
+                return String.valueOf(clientCommandSource.getLevel().players().stream().anyMatch(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)));
             }
             return "false";
         });
         this.functionMap.put("get_time", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                return String.valueOf(serverCommandSource.getWorld().getTime());
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                return String.valueOf(serverCommandSource.getLevel().getGameTime());
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                return String.valueOf(clientCommandSource.getWorld().getTime());
+                return String.valueOf(clientCommandSource.getLevel().getGameTime());
             }
             return null;
         });
         this.functionMap.put("get_time_of_day", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                return String.valueOf(serverCommandSource.getWorld().getTimeOfDay());
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                return String.valueOf(serverCommandSource.getLevel().getDefaultClockTime());
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                return String.valueOf(clientCommandSource.getWorld().getTimeOfDay());
+                return String.valueOf(clientCommandSource.getLevel().getDefaultClockTime());
             }
             return null;
         });
         this.functionMap.put("get_lunar_time", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                return String.valueOf(serverCommandSource.getWorld().getLunarTime());
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                return String.valueOf(serverCommandSource.getLevel().getDefaultClockTime());
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                return String.valueOf(clientCommandSource.getWorld().getLunarTime());
+                return String.valueOf(clientCommandSource.getLevel().getDefaultClockTime());
             }
             return null;
         });
         this.functionMap.put("get_dimension", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return optionalPlayer.get().getEntityWorld().getRegistryKey().getValue().toString();
+                    return optionalPlayer.get().level().dimension().identifier().toString();
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return optionalPlayer.get().getEntityWorld().getRegistryKey().getValue().toString();
+                    return optionalPlayer.get().level().dimension().identifier().toString();
                 }
             }
             return null;
         });
         this.functionMap.put("get_world", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return optionalPlayer.get().getEntityWorld().getDimension().effects().toString();
+                    return optionalPlayer.get().level().dimension().identifier().toString();
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return clientCommandSource.getWorld().getDimension().effects().toString();
+                    return clientCommandSource.getLevel().dimension().identifier().toString();
                 }
             }
             return null;
         });
         this.functionMap.put("get_block_pos_x", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getBlockX());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getBlockX());
                 }
@@ -138,15 +138,15 @@ public class FunctionProcessor<S extends CommandSource> {
             return null;
         });
         this.functionMap.put("get_block_pos_y", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getBlockY());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getBlockY());
                 }
@@ -154,15 +154,15 @@ public class FunctionProcessor<S extends CommandSource> {
             return null;
         });
         this.functionMap.put("get_block_pos_z", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getBlockZ());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getBlockZ());
                 }
@@ -170,47 +170,47 @@ public class FunctionProcessor<S extends CommandSource> {
             return null;
         });
         this.functionMap.put("get_yaw", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return String.valueOf(optionalPlayer.get().getYaw());
+                    return String.valueOf(optionalPlayer.get().getYRot());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return String.valueOf(optionalPlayer.get().getYaw());
+                    return String.valueOf(optionalPlayer.get().getYRot());
                 }
             }
             return null;
         });
         this.functionMap.put("get_pitch", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return String.valueOf(optionalPlayer.get().getPitch());
+                    return String.valueOf(optionalPlayer.get().getXRot());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
-                    return String.valueOf(optionalPlayer.get().getPitch());
+                    return String.valueOf(optionalPlayer.get().getXRot());
                 }
             }
             return null;
         });
         this.functionMap.put("get_pos_x", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getX());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getX());
                 }
@@ -218,15 +218,15 @@ public class FunctionProcessor<S extends CommandSource> {
             return null;
         });
         this.functionMap.put("get_pos_y", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getY());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getY());
                 }
@@ -234,15 +234,15 @@ public class FunctionProcessor<S extends CommandSource> {
             return null;
         });
         this.functionMap.put("get_pos_z", (commandSource, input) -> {
-            if (commandSource instanceof ServerCommandSource serverCommandSource) {
-                Optional<ServerPlayerEntity> optionalPlayer = serverCommandSource.getWorld().getPlayers().stream()
-                        .filter(serverPlayerEntity -> serverPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+            if (commandSource instanceof CommandSourceStack serverCommandSource) {
+                Optional<ServerPlayer> optionalPlayer = serverCommandSource.getLevel().players().stream()
+                        .filter(serverPlayerEntity -> serverPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getZ());
                 }
             } else if (commandSource instanceof FabricClientCommandSource clientCommandSource) {
-                Optional<AbstractClientPlayerEntity> optionalPlayer = clientCommandSource.getWorld().getPlayers().stream()
-                        .filter(clientPlayerEntity -> clientPlayerEntity.getNameForScoreboard().equals(input)).findFirst();
+                Optional<AbstractClientPlayer> optionalPlayer = clientCommandSource.getLevel().players().stream()
+                        .filter(clientPlayerEntity -> clientPlayerEntity.getScoreboardName().equals(input)).findFirst();
                 if (optionalPlayer.isPresent()) {
                     return String.valueOf(optionalPlayer.get().getZ());
                 }
@@ -305,7 +305,7 @@ public class FunctionProcessor<S extends CommandSource> {
         });
     }
 
-    public String processFunctions(String original, CommandSource commandSource) {
+    public String processFunctions(String original, SharedSuggestionProvider commandSource) {
         String modified = original;
         Matcher matcher = this.singleArgumentFunction.matcher(modified);
         while (matcher.find()) {
@@ -317,7 +317,7 @@ public class FunctionProcessor<S extends CommandSource> {
                 throw new IllegalArgumentException("Invalid function name : " + functionName);
             }
 
-            BiFunction<CommandSource, String, String> function = this.functionMap.get(functionName);
+            BiFunction<SharedSuggestionProvider, String, String> function = this.functionMap.get(functionName);
 
             String value = function.apply(commandSource, arg);
             modified = modified.replace(matcher.group(), Objects.requireNonNullElse(value, "null"));
@@ -327,7 +327,7 @@ public class FunctionProcessor<S extends CommandSource> {
         return modified;
     }
 
-    public Map<String, BiFunction<CommandSource, String, String>> getFunctionMap() {
+    public Map<String, BiFunction<SharedSuggestionProvider, String, String>> getFunctionMap() {
         return functionMap;
     }
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/loader/AbstractCommandAliasesProvider.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/loader/AbstractCommandAliasesProvider.java
@@ -31,16 +31,15 @@ import me.flashyreese.mods.commandaliases.storage.database.AbstractDatabase;
 import me.flashyreese.mods.commandaliases.util.TreeNode;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.command.CommandSource;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
@@ -53,7 +52,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @version 1.0.0
  * @since 0.9.0
  */
-public abstract class AbstractCommandAliasesProvider<S extends CommandSource> {
+public abstract class AbstractCommandAliasesProvider<S extends SharedSuggestionProvider> {
     private final ObjectMapper jsonMapper = new JsonMapper();
     private final ObjectMapper json5Mapper = new JsonMapper(JsonFactory.builder().enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
             .enable(JsonReadFeature.ALLOW_TRAILING_COMMA).enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
@@ -68,25 +67,26 @@ public abstract class AbstractCommandAliasesProvider<S extends CommandSource> {
     private final List<String> loadedCommands = new ObjectArrayList<>();
     private final Map<String, String> reassignedCommandMap = new Object2ObjectOpenHashMap<>();
     private final Path commandsDirectory;
-    private final Field literalCommandNodeLiteralField;
     private final String rootCommand;
     private final CommandType commandType;
     private AbstractDatabase<String, String> database;
     private Scheduler scheduler;
 
-    public AbstractCommandAliasesProvider(Path commandsDirectory, Field literalCommandNodeLiteralField, String rootCommand, CommandType commandType) {
+    public AbstractCommandAliasesProvider(Path commandsDirectory, java.lang.reflect.Field literalCommandNodeLiteralField, String rootCommand, CommandType commandType) {
         this.commandsDirectory = commandsDirectory;
         this.literalCommandNodeLiteralField = literalCommandNodeLiteralField;
         this.rootCommand = rootCommand;
         this.commandType = commandType;
     }
 
+    private final java.lang.reflect.Field literalCommandNodeLiteralField;
+
     /**
      * Registers all server Command Aliases' custom commands.
      *
      * @param dispatcher Server CommandDispatcher
      */
-    protected void registerCommands(CommandDispatcher<S> dispatcher, CommandRegistryAccess registryAccess) {
+    protected void registerCommands(CommandDispatcher<S> dispatcher, CommandBuildContext registryAccess) {
         // Load reassignments first
         this.getCommands().entrySet().stream().filter(cmd -> cmd.getValue().getCommandMode() == CommandMode.COMMAND_REASSIGN).forEach(cmd -> {
             if (cmd.getValue().getCommandMode() == CommandMode.COMMAND_REASSIGN && cmd.getValue() instanceof ReassignCommand reassignCommand) {
@@ -119,16 +119,16 @@ public abstract class AbstractCommandAliasesProvider<S extends CommandSource> {
      *
      * @param dispatcher The CommandDispatcher
      */
-    protected void registerCommandAliasesCommands(CommandDispatcher<S> dispatcher, CommandRegistryAccess registryAccess) {
+    protected void registerCommandAliasesCommands(CommandDispatcher<S> dispatcher, CommandBuildContext registryAccess) {
         dispatcher.register(this.literal(this.rootCommand).requires(Permissions.require("commandaliases", 4))
                 .executes(context -> {
                     Optional<ModContainer> modContainerOptional = FabricLoader.getInstance().getModContainer("commandaliases");
-                    modContainerOptional.ifPresent(modContainer -> this.sendFeedback(context.getSource(), Text.literal("Running Command Aliases")
-                            .formatted(Formatting.YELLOW)
-                            .append(Text.literal(" v" + modContainer.getMetadata().getVersion()).formatted(Formatting.RED))
-                            .formatted(Formatting.RESET)
-                            .append(Text.literal(", "))
-                            .append(Text.literal("Click here to visit the wiki.").formatted(Formatting.UNDERLINE, Formatting.AQUA).styled(style -> style.withClickEvent(new ClickEvent.OpenUrl(URI.create("https://wiki.commandaliases.flashyreese.me/")))))
+                    modContainerOptional.ifPresent(modContainer -> this.sendFeedback(context.getSource(), Component.literal("Running Command Aliases")
+                            .withStyle(ChatFormatting.YELLOW)
+                            .append(Component.literal(" v" + modContainer.getMetadata().getVersion()).withStyle(ChatFormatting.RED))
+                            .withStyle(ChatFormatting.RESET)
+                            .append(Component.literal(", "))
+                            .append(Component.literal("Click here to visit the wiki.").withStyle(ChatFormatting.UNDERLINE, ChatFormatting.AQUA).withStyle(style -> style.withClickEvent(new ClickEvent.OpenUrl(URI.create("https://wiki.commandaliases.flashyreese.me/")))))
                     ));
 
                     return Command.SINGLE_SUCCESS;
@@ -361,7 +361,7 @@ public abstract class AbstractCommandAliasesProvider<S extends CommandSource> {
                                             String key = StringArgumentType.getString(context, "key");
                                             String value = this.getDatabase().read(key);
                                             if (value != null) {
-                                                this.sendFeedback(context.getSource(), Text.literal(value));
+                                                this.sendFeedback(context.getSource(), Component.literal(value));
                                             }
                                             return Command.SINGLE_SUCCESS;
                                         })
@@ -380,15 +380,15 @@ public abstract class AbstractCommandAliasesProvider<S extends CommandSource> {
         );
     }
 
-    protected abstract void sendFeedback(S source, Text text);
+    protected abstract void sendFeedback(S source, Component text);
 
-    protected abstract int commandAliasesLoad(CommandContext<S> context, CommandDispatcher<S> dispatcher, CommandRegistryAccess registryAccess);
+    protected abstract int commandAliasesLoad(CommandContext<S> context, CommandDispatcher<S> dispatcher, CommandBuildContext registryAccess);
 
-    protected abstract int commandAliasesUnload(CommandContext<S> context, CommandDispatcher<S> dispatcher, CommandRegistryAccess registryAccess);
+    protected abstract int commandAliasesUnload(CommandContext<S> context, CommandDispatcher<S> dispatcher, CommandBuildContext registryAccess);
 
-    protected abstract int commandAliasesReload(CommandContext<S> context, CommandDispatcher<S> dispatcher, CommandRegistryAccess registryAccess);
+    protected abstract int commandAliasesReload(CommandContext<S> context, CommandDispatcher<S> dispatcher, CommandBuildContext registryAccess);
 
-    protected abstract LiteralArgumentBuilder<S> buildCustomCommand(String filePath, CustomCommand customCommand, AbstractCommandAliasesProvider<S> abstractCommandAliasesProvider, CommandRegistryAccess registryAccess, CommandDispatcher<S> dispatcher);
+    protected abstract LiteralArgumentBuilder<S> buildCustomCommand(String filePath, CustomCommand customCommand, AbstractCommandAliasesProvider<S> abstractCommandAliasesProvider, CommandBuildContext registryAccess, CommandDispatcher<S> dispatcher);
 
     /**
      * Loads command aliases file, meant for integrated/dedicated servers.

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/loader/ClientCommandAliasesProvider.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/loader/ClientCommandAliasesProvider.java
@@ -9,8 +9,8 @@ import me.flashyreese.mods.commandaliases.command.builder.custom.ClientCustomCom
 import me.flashyreese.mods.commandaliases.command.builder.custom.format.CustomCommand;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.text.Text;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.network.chat.Component;
 
 import java.lang.reflect.Field;
 
@@ -20,39 +20,39 @@ public class ClientCommandAliasesProvider extends AbstractCommandAliasesProvider
     }
 
     @Override
-    protected void sendFeedback(FabricClientCommandSource source, Text text) {
+    protected void sendFeedback(FabricClientCommandSource source, Component text) {
         source.sendFeedback(text);
     }
 
     @Override
-    protected int commandAliasesLoad(CommandContext<FabricClientCommandSource> context, CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        this.sendFeedback(context.getSource(), Text.literal("Loading all client Command Aliases!"));
+    protected int commandAliasesLoad(CommandContext<FabricClientCommandSource> context, CommandDispatcher<FabricClientCommandSource> dispatcher, CommandBuildContext registryAccess) {
+        this.sendFeedback(context.getSource(), Component.literal("Loading all client Command Aliases!"));
         this.loadCommandAliases();
         this.registerCommands(dispatcher, registryAccess);
-        this.sendFeedback(context.getSource(), Text.literal("Loaded all client Command Aliases!"));
+        this.sendFeedback(context.getSource(), Component.literal("Loaded all client Command Aliases!"));
         return Command.SINGLE_SUCCESS;
     }
 
     @Override
-    protected int commandAliasesUnload(CommandContext<FabricClientCommandSource> context, CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        this.sendFeedback(context.getSource(), Text.literal("Unloading all client Command Aliases!"));
+    protected int commandAliasesUnload(CommandContext<FabricClientCommandSource> context, CommandDispatcher<FabricClientCommandSource> dispatcher, CommandBuildContext registryAccess) {
+        this.sendFeedback(context.getSource(), Component.literal("Unloading all client Command Aliases!"));
         this.unregisterCommands(dispatcher);
-        this.sendFeedback(context.getSource(), Text.literal("Unloaded all client Command Aliases!"));
+        this.sendFeedback(context.getSource(), Component.literal("Unloaded all client Command Aliases!"));
         return Command.SINGLE_SUCCESS;
     }
 
     @Override
-    protected int commandAliasesReload(CommandContext<FabricClientCommandSource> context, CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        this.sendFeedback(context.getSource(), Text.literal("Reloading all client Command Aliases!"));
+    protected int commandAliasesReload(CommandContext<FabricClientCommandSource> context, CommandDispatcher<FabricClientCommandSource> dispatcher, CommandBuildContext registryAccess) {
+        this.sendFeedback(context.getSource(), Component.literal("Reloading all client Command Aliases!"));
         this.unregisterCommands(dispatcher);
         this.loadCommandAliases();
         this.registerCommands(dispatcher, registryAccess);
-        this.sendFeedback(context.getSource(), Text.literal("Reloaded all client Command Aliases!"));
+        this.sendFeedback(context.getSource(), Component.literal("Reloaded all client Command Aliases!"));
         return Command.SINGLE_SUCCESS;
     }
 
     @Override
-    protected LiteralArgumentBuilder<FabricClientCommandSource> buildCustomCommand(String filePath, CustomCommand customCommand, AbstractCommandAliasesProvider<FabricClientCommandSource> abstractCommandAliasesProvider, CommandRegistryAccess registryAccess, CommandDispatcher<FabricClientCommandSource> dispatcher) {
+    protected LiteralArgumentBuilder<FabricClientCommandSource> buildCustomCommand(String filePath, CustomCommand customCommand, AbstractCommandAliasesProvider<FabricClientCommandSource> abstractCommandAliasesProvider, CommandBuildContext registryAccess, CommandDispatcher<FabricClientCommandSource> dispatcher) {
         return new ClientCustomCommandBuilder(filePath, customCommand, abstractCommandAliasesProvider, registryAccess).buildCommand(dispatcher);
     }
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/loader/CommandAliasesLoader.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/loader/CommandAliasesLoader.java
@@ -17,9 +17,9 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.WorldSavePath;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.storage.LevelResource;
 
 import java.lang.reflect.Field;
 
@@ -32,8 +32,8 @@ import java.lang.reflect.Field;
  */
 public class CommandAliasesLoader {
 
-    private static final Identifier ALIASES_REGISTRATION_PHASE_ID = Identifier.of("commandaliases", "register_aliases_phase");
-    private final AbstractCommandAliasesProvider<ServerCommandSource> serverCommandAliasesProvider;
+    private static final Identifier ALIASES_REGISTRATION_PHASE_ID = Identifier.fromNamespaceAndPath("commandaliases", "register_aliases_phase");
+    private final AbstractCommandAliasesProvider<CommandSourceStack> serverCommandAliasesProvider;
     private final AbstractCommandAliasesProvider<FabricClientCommandSource> clientCommandAliasesProvider;
 
     public CommandAliasesLoader() {
@@ -65,7 +65,7 @@ public class CommandAliasesLoader {
                 if (CommandAliasesMod.options().databaseSettings.databaseMode == CommandAliasesConfig.DatabaseMode.IN_MEMORY) {
                     this.serverCommandAliasesProvider.setDatabase(new InMemoryImpl());
                 } else if (CommandAliasesMod.options().databaseSettings.databaseMode == CommandAliasesConfig.DatabaseMode.LEVELDB) {
-                    this.serverCommandAliasesProvider.setDatabase(new LevelDBImpl(server.getSavePath(WorldSavePath.ROOT).resolve("commandaliases").toString()));
+                    this.serverCommandAliasesProvider.setDatabase(new LevelDBImpl(server.getWorldPath(LevelResource.ROOT).resolve("commandaliases").toString()));
                 } else if (CommandAliasesMod.options().databaseSettings.databaseMode == CommandAliasesConfig.DatabaseMode.MYSQL) {
                     this.serverCommandAliasesProvider.setDatabase(new MySQLImpl(CommandAliasesMod.options().databaseSettings.host, CommandAliasesMod.options().databaseSettings.port, CommandAliasesMod.options().databaseSettings.database, CommandAliasesMod.options().databaseSettings.user, CommandAliasesMod.options().databaseSettings.password, "server"));
                 } else if (CommandAliasesMod.options().databaseSettings.databaseMode == CommandAliasesConfig.DatabaseMode.REDIS) {

--- a/src/main/java/me/flashyreese/mods/commandaliases/command/loader/ServerCommandAliasesProvider.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/command/loader/ServerCommandAliasesProvider.java
@@ -9,66 +9,65 @@ import me.flashyreese.mods.commandaliases.command.CommandType;
 import me.flashyreese.mods.commandaliases.command.builder.custom.ServerCustomCommandBuilder;
 import me.flashyreese.mods.commandaliases.command.builder.custom.format.CustomCommand;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 
 import java.lang.reflect.Field;
 
-public class ServerCommandAliasesProvider extends AbstractCommandAliasesProvider<ServerCommandSource> {
+public class ServerCommandAliasesProvider extends AbstractCommandAliasesProvider<CommandSourceStack> {
     public ServerCommandAliasesProvider(Field literalCommandNodeLiteralField) {
         super(FabricLoader.getInstance().getConfigDir().resolve("commandaliases"), literalCommandNodeLiteralField, "commandaliases", CommandType.SERVER);
     }
 
     @Override
-    protected void sendFeedback(ServerCommandSource source, Text text) {
-        source.sendFeedback(() -> text, CommandAliasesMod.options().debugSettings.broadcastToOps);
+    protected void sendFeedback(CommandSourceStack source, Component text) {
+        source.sendSuccess(() -> text, CommandAliasesMod.options().debugSettings.broadcastToOps);
     }
 
     @Override
-    protected int commandAliasesLoad(CommandContext<ServerCommandSource> context, CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        this.sendFeedback(context.getSource(), Text.literal("Loading all Command Aliases!"));
+    protected int commandAliasesLoad(CommandContext<CommandSourceStack> context, CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext registryAccess) {
+        this.sendFeedback(context.getSource(), Component.literal("Loading all Command Aliases!"));
         this.loadCommandAliases();
         this.registerCommands(dispatcher, registryAccess);
 
-        for (ServerPlayerEntity e : context.getSource().getServer().getPlayerManager().getPlayerList()) {
-            context.getSource().getServer().getPlayerManager().sendCommandTree(e);
+        for (ServerPlayer e : context.getSource().getServer().getPlayerList().getPlayers()) {
+            context.getSource().getServer().getCommands().sendCommands(e);
         }
-        this.sendFeedback(context.getSource(), Text.literal("Loaded all Command Aliases!"));
+        this.sendFeedback(context.getSource(), Component.literal("Loaded all Command Aliases!"));
         return Command.SINGLE_SUCCESS;
     }
 
     @Override
-    protected int commandAliasesUnload(CommandContext<ServerCommandSource> context, CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        this.sendFeedback(context.getSource(), Text.literal("Unloading all Command Aliases!"));
+    protected int commandAliasesUnload(CommandContext<CommandSourceStack> context, CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext registryAccess) {
+        this.sendFeedback(context.getSource(), Component.literal("Unloading all Command Aliases!"));
         this.unregisterCommands(dispatcher);
 
-        for (ServerPlayerEntity e : context.getSource().getServer().getPlayerManager().getPlayerList()) {
-            context.getSource().getServer().getPlayerManager().sendCommandTree(e);
+        for (ServerPlayer e : context.getSource().getServer().getPlayerList().getPlayers()) {
+            context.getSource().getServer().getCommands().sendCommands(e);
         }
-        this.sendFeedback(context.getSource(), Text.literal("Unloaded all Command Aliases!"));
+        this.sendFeedback(context.getSource(), Component.literal("Unloaded all Command Aliases!"));
         return Command.SINGLE_SUCCESS;
     }
 
     @Override
-    protected int commandAliasesReload(CommandContext<ServerCommandSource> context, CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        this.sendFeedback(context.getSource(), Text.literal("Reloading all Command Aliases!"));
+    protected int commandAliasesReload(CommandContext<CommandSourceStack> context, CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext registryAccess) {
+        this.sendFeedback(context.getSource(), Component.literal("Reloading all Command Aliases!"));
         this.unregisterCommands(dispatcher);
         this.loadCommandAliases();
         this.registerCommands(dispatcher, registryAccess);
 
-        //Update Command Tree
-        for (ServerPlayerEntity e : context.getSource().getServer().getPlayerManager().getPlayerList()) {
-            context.getSource().getServer().getPlayerManager().sendCommandTree(e);
+        for (ServerPlayer e : context.getSource().getServer().getPlayerList().getPlayers()) {
+            context.getSource().getServer().getCommands().sendCommands(e);
         }
 
-        this.sendFeedback(context.getSource(), Text.literal("Reloaded all Command Aliases!"));
+        this.sendFeedback(context.getSource(), Component.literal("Reloaded all Command Aliases!"));
         return Command.SINGLE_SUCCESS;
     }
 
     @Override
-    protected LiteralArgumentBuilder<ServerCommandSource> buildCustomCommand(String filePath, CustomCommand customCommand, AbstractCommandAliasesProvider<ServerCommandSource> abstractCommandAliasesProvider, CommandRegistryAccess registryAccess, CommandDispatcher<ServerCommandSource> dispatcher) {
+    protected LiteralArgumentBuilder<CommandSourceStack> buildCustomCommand(String filePath, CustomCommand customCommand, AbstractCommandAliasesProvider<CommandSourceStack> abstractCommandAliasesProvider, CommandBuildContext registryAccess, CommandDispatcher<CommandSourceStack> dispatcher) {
         return new ServerCustomCommandBuilder(filePath, customCommand, abstractCommandAliasesProvider, registryAccess).buildCommand(dispatcher);
     }
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/mixin/MixinCommandManager.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/mixin/MixinCommandManager.java
@@ -1,36 +1,36 @@
 package me.flashyreese.mods.commandaliases.mixin;
 
 import me.flashyreese.mods.commandaliases.command.CommandManagerExtended;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.server.command.CommandManager;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.Commands;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(CommandManager.class)
+@Mixin(Commands.class)
 public class MixinCommandManager implements CommandManagerExtended {
 
     @Unique
-    private CommandManager.RegistrationEnvironment environment;
+    private Commands.CommandSelection environment;
 
     @Unique
-    private CommandRegistryAccess commandRegistryAccess;
+    private CommandBuildContext commandRegistryAccess;
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    private void clint(CommandManager.RegistrationEnvironment environment, CommandRegistryAccess commandRegistryAccess, CallbackInfo ci) {
+    private void clint(Commands.CommandSelection environment, CommandBuildContext commandRegistryAccess, CallbackInfo ci) {
         this.environment = environment;
         this.commandRegistryAccess = commandRegistryAccess;
     }
 
     @Override
-    public CommandManager.RegistrationEnvironment getEnvironment() {
+    public Commands.CommandSelection getEnvironment() {
         return this.environment;
     }
 
     @Override
-    public CommandRegistryAccess getCommandRegistryAccess() {
+    public CommandBuildContext getCommandRegistryAccess() {
         return this.commandRegistryAccess;
     }
 }

--- a/src/main/java/me/flashyreese/mods/commandaliases/util/CommandAliasesPlaceholders.java
+++ b/src/main/java/me/flashyreese/mods/commandaliases/util/CommandAliasesPlaceholders.java
@@ -4,15 +4,15 @@ import eu.pb4.placeholders.api.PlaceholderResult;
 import eu.pb4.placeholders.api.Placeholders;
 import me.flashyreese.mods.commandaliases.command.impl.FunctionProcessor;
 import me.flashyreese.mods.commandaliases.command.loader.ServerCommandAliasesProvider;
-import net.minecraft.server.command.ServerCommandSource;
-import net.minecraft.util.Identifier;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.resources.Identifier;
 
 import static me.flashyreese.mods.commandaliases.CommandAliasesMod.MOD_ID;
 
 public class CommandAliasesPlaceholders {
     public static void register(ServerCommandAliasesProvider serverCommandAliasesProvider) {
-        FunctionProcessor<ServerCommandSource> functionProcessor = new FunctionProcessor<>(serverCommandAliasesProvider);
+        FunctionProcessor<CommandSourceStack> functionProcessor = new FunctionProcessor<>(serverCommandAliasesProvider);
 
-        functionProcessor.getFunctionMap().forEach((key, value) -> Placeholders.register(Identifier.of(MOD_ID, key), ((context, argument) -> PlaceholderResult.value(value.apply(context.source(), argument)))));
+        functionProcessor.getFunctionMap().forEach((key, value) -> Placeholders.registerServer(Identifier.fromNamespaceAndPath(MOD_ID, key), ((context, argument) -> PlaceholderResult.value(value.apply(context.commandSourceStack(), argument)))));
     }
 }

--- a/src/main/resources/commandaliases.mixins.json
+++ b/src/main/resources/commandaliases.mixins.json
@@ -1,7 +1,7 @@
 {
   "package": "me.flashyreese.mods.commandaliases.mixin",
   "required": true,
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_25",
   "injectors": {
     "defaultRequire": 1
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,8 +44,8 @@
     "commandaliases.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.17.2",
-    "fabric": "*",
-    "minecraft": ">=1.21.9"
+    "fabricloader": ">=0.19.2",
+    "fabric-api": "*",
+    "minecraft": ">=26.1.2"
   }
 }


### PR DESCRIPTION
- Bump minecraft_version to 26.1.2, loader_version, fabric_version
- Upgrade Gradle wrapper to 9.4.0, Java toolchain to 25
- Switch to Fabric Loom 1.16 (no modImplementation for unobfuscated MC)
- Add Foojay toolchain resolver 1.0.0 for auto Java 25 download
- Migrate all Yarn mappings to Mojang native source names across the codebase
- Update Placeholder API usage to 3.0.0+26.1 (registerServer, ServerPlaceholderContext, SERVER_PLACEHOLDER_PARSER)
- Fix removed time APIs: getDayTime/getLunarTime -> getDefaultClockTime
- Fix removed DimensionType.effectsLocation -> dimension().identifier()
- Fix ResourceKey.location() -> ResourceKey.identifier()
- Fix renamed argument types: DisplaySlotArgument, ResourceLocationArgument, MirrorArgument, StructureRotationArgument
- Fix ClientPacketListener.sendChatCommand -> sendCommand